### PR TITLE
Remove obsolete `.upload_file`

### DIFF
--- a/wikiapi.js
+++ b/wikiapi.js
@@ -654,9 +654,9 @@ function wikiapi_register_redirects(template_name, options) {
 // --------------------------------------------------------
 
 // Upload a local file directly:
-//let result = await wiki_session.upload_file({ file_path: '/local/file/path', comment: '', });
+//let result = await wiki_session.upload({ file_path: '/local/file/path', comment: '', });
 // Upload file from URL:
-//let result = await wiki_session.upload_file({ media_url: 'https://media.url/name.jpg', comment: '', });
+//let result = await wiki_session.upload({ media_url: 'https://media.url/name.jpg', comment: '', });
 // Other file_data options: @see https://github.com/kanasimi/CeJS/blob/master/application/net/wiki/edit.js#L912 /options.text/
 // filename:'Will set via .file_path or .media_url if not settled.',
 // text: '', text: { description: '', source: '', author: '', permission: '',... },


### PR DESCRIPTION
Recent changes now use `.upload`, see [this line](https://github.com/kanasimi/wikiapi/blob/master/wikiapi.js#L973). My change only update comments, not actual codes.